### PR TITLE
update Debian packaging scripts

### DIFF
--- a/port-files/debian/changelog
+++ b/port-files/debian/changelog
@@ -1,3 +1,22 @@
+lumina-desktop (1.0.0~beta2+git1581-1nano) unstable; urgency=low
+
+  * New git snapshot
+  * update supplied wrapper for using qt5ct with lumina
+  * update supplied vendor configuration for lumina
+    - same as previous
+    - add iceweasel, icedove, mpv, xarchiver, konsole to list of known
+      applications to look for (firefox and thunderbird already were)
+  * move usbmount from Depends to Recommends
+  * move pavucontrol from Depends to Recommends
+    - Note: pavucontrol is still needed for the graphical mixer utility,
+            not having pavucontrol installed will disable the mixer
+  * add xarchiver to Recommends
+  * update for changes since 0.9.1
+    - new, removed, moved files
+    - new qmake flag for enabling translations
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Tue, 12 Jul 2016 18:22:23 +0200
+
 lumina-desktop (0.9.1.1421-1nano) unstable; urgency=low
 
   * new git snapshot

--- a/port-files/debian/control
+++ b/port-files/debian/control
@@ -20,9 +20,9 @@ Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version
          lumina-open, lumina-screenshot, lumina-search, lumina-info,
          lumina-xconfig, lumina-fileinfo, lxpolkit, lumina-data,
          lumina-textedit, fluxbox, numlockx, xbacklight, xscreensaver,
-         usbmount, alsa-utils, acpi, gstreamer1.0-plugins-base,
-         phonon4qt5-backend-gstreamer, pavucontrol, procps, sysstat
-Recommends: qt5-configuration-tool
+         alsa-utils, acpi, gstreamer1.0-plugins-base, procps, sysstat,
+         phonon4qt5-backend-gstreamer
+Recommends: qt5-configuration-tool, usbmount, xarchiver, pavucontrol
 Description: Lightweight Qt5-based desktop environment
  Metapackage depending on all other lumina packages.
 

--- a/port-files/debian/lumina-config.install
+++ b/port-files/debian/lumina-config.install
@@ -1,2 +1,3 @@
 usr/bin/lumina-config
+usr/share/applications/lumina-config.desktop
 usr/share/lumina-desktop/i18n/lumina-config*.qm

--- a/port-files/debian/lumina-data.install
+++ b/port-files/debian/lumina-data.install
@@ -7,6 +7,7 @@ usr/share/lumina-desktop/fluxbox-init-rc
 usr/share/lumina-desktop/fluxbox-keys
 usr/share/lumina-desktop/Login.ogg
 usr/share/lumina-desktop/Logout.ogg
+usr/share/lumina-desktop/menu-scripts/ls.json.sh
 usr/share/lumina-desktop/luminaDesktop.conf
 usr/share/lumina-desktop/i18n/lumina-desktop*.qm
 usr/share/wallpapers/Lumina-DE/

--- a/port-files/debian/lumina-desktop.wrapper
+++ b/port-files/debian/lumina-desktop.wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. /etc/default/lumina-qt5ct
+
+if test -f /usr/bin/qt5ct && test ${LUMINA_USE_QT5CT} = TRUE; then
+	export QT_QPA_PLATFORMTHEME=qt5ct
+fi
+
+/usr/bin/lumina-desktop.real

--- a/port-files/debian/lumina-fileinfo.install
+++ b/port-files/debian/lumina-fileinfo.install
@@ -1,2 +1,3 @@
-/usr/bin/lumina-fileinfo
-/usr/share/lumina-desktop/i18n/lumina-fileinfo*.qm
+usr/bin/lumina-fileinfo
+usr/share/applications/lumina-fileinfo.desktop
+usr/share/lumina-desktop/i18n/lumina-fileinfo*.qm

--- a/port-files/debian/lumina-fm.install
+++ b/port-files/debian/lumina-fm.install
@@ -1,3 +1,4 @@
 usr/bin/lumina-fm
 usr/share/applications/lumina-fm.desktop
+usr/share/pixmaps/Insight-FileManager.png
 usr/share/lumina-desktop/i18n/lumina-fm*.qm

--- a/port-files/debian/lumina-textedit.install
+++ b/port-files/debian/lumina-textedit.install
@@ -1,3 +1,4 @@
 usr/bin/lumina-textedit
+usr/bin/lte
 usr/share/applications/lumina-textedit.desktop
 usr/share/lumina-desktop/i18n/lumina-textedit*.qm

--- a/port-files/debian/lumina-xconfig.install
+++ b/port-files/debian/lumina-xconfig.install
@@ -1,2 +1,3 @@
 usr/bin/lumina-xconfig
+usr/share/applications/lumina-xconfig.desktop
 usr/share/lumina-desktop/i18n/lumina-xconfig*.qm

--- a/port-files/debian/luminaDesktop.conf
+++ b/port-files/debian/luminaDesktop.conf
@@ -1,17 +1,17 @@
 #This is the configuration file that generates all the default settings files for the Lumina desktop
 # For any setting that can take a list of values, each vale needs to be seperated by a comma and a space (", ")
-#    Example: some.setting=item1, item2, item3
+#    Example: some_setting=item1, item2, item3
 
 #NOTE: To pre-setup default applications for particular mime-types, you need to create *.desktop entries on
 #  system corresponding to the XDG mime-type specifications for default applications
-#  See Here for specifications: http://www.freedesktop_org/wiki/Specifications/mime-apps-spec/
+#  See Here for specifications: http://www.freedesktop.org/wiki/Specifications/mime-apps-spec/
 
-# Possible Desktop Plugins (Lumina version 0.8.4): 
-#   calendar, applauncher[::absolute path to *.desktop file], desktopview, notepad, audioplayer
-# Possible Panel Plugins (Lumina version 0.8.4):
-#   userbutton, desktopbar, spacer, desktopswitcher, battery, clock, systemdashboard
+# Possible Desktop Plugins (Lumina version 0.9.1): 
+#   calendar, applauncher[::absolute path to *.desktop file], desktopview, notepad, audioplayer, rssreader
+# Possible Panel Plugins (Lumina version 0.9.1):
+#   userbutton, desktopbar, spacer, desktopswitcher, battery, clock, systemdashboard, systemstart
 #   taskmanager[-nogroups], systemtray, homebutton, appmenu, applauncher[::absolute path to *.desktop file]
-# Possible Menu Plugins (Lumina version 0.8.4):
+# Possible Menu Plugins (Lumina version 0.9.1):
 #   terminal, filemanager, applications, line, settings, windowlist, app::<absolute path to *.desktop file>
 
 #GENERAL SESSION SETTINGS 
@@ -22,30 +22,62 @@ session_playlogoutaudio=false #[true/false] Play the audio chimes on log out
 # DEFAULT UTILITIES
 # Provide the full path to *.desktop file, or a binary name which exists on PATH
 # *.desktop files provide better support for input formats, and are recommended
-#session_default_terminal=xterm
-#session_default_filemanager=lumina-fm 
-#session_default_webbrowser=arora
-#session_default_email=icedove
+#Note: the last "ifexists" entry has the highest priority for each session utility
+session_default_terminal_ifexists=xterm.desktop
+session_default_terminal_ifexists=konsole.desktop
+session_default_terminal_ifexists=lumina-terminal.desktop
+
+session_default_filemanager=lumina-fm.desktop
+
+session_default_webbrowser_ifexists=chromium-browser.desktop
+session_default_webbrowser_ifexists=qupzilla.desktop
+session_default_webbrowser_ifexists=iceweasel.desktop
+session_default_webbrowser_ifexists=firefox.desktop
+
+session_default_email_ifexists=trojita.desktop
+session_default_email_ifexists=icedove.desktop
+session_default_email_ifexists=thunderbird.desktop
+
+#DEFAULT UTILITIES FOR INDIVIDUAL MIME TYPES
+# Format: mime_default_<mimetype>[_ifexists]=<*.desktop file>
+mime_default_text/*_ifexists=lumina-textedit.desktop
+
+mime_default_audio/*_ifexists=vlc.desktop
+mime_default_video/*_ifexists=vlc.desktop
+mime_default_audio/*_ifexists=mpv.desktop
+mime_default_video/*_ifexists=mpv.desktop
+
+mime_default_application/zip_ifexists=xarchiver.desktop
+mime_default_application/x-compressed-tar_ifexists=xarchiver.desktop
+mime_default_application/x-bzip-compressed-tar_ifexists=xarchiver.desktop
+mime_default_application/x-lrzip-compressed-tar_ifexists=xarchiver.desktop
+mime_default_application/x-lzma-compressed-tar_ifexists=xarchiver.desktop
+mime_default_application/x-xz-compressed-tar_ifexists=xarchiver.desktop
+mime_default_application/x-tar_ifexists=xarchiver.desktop
+
+mime_default_unknown/*=lumina-textedit.desktop
+mime_default_application/x-shellscript=lumina-textedit.desktop
 
 #THEME SETTINGS
-theme_themefile=/usr/share/Lumina-DE/themes/None.qss.template #Absolute path to the theme template file to use (disable for Lumina-Default)
-#theme_colorfile=<file path> #Absolute path to the color spec file to use for theming
+theme_themefile=Glass #Name of the theme to use (disable for Lumina-Default)
+theme_colorfile=Grey-Dark #Name of the color spec file to use for theming
 theme_iconset=oxygen #Name of the icon theme to use
-theme_font=DejaVu Sans #Name of the font family to use
-theme_fontsize=9pt #Default size of the fonts to use on the desktop
+theme_font=Arial #Name of the font family to use
+theme_fontsize=10pt #Default size of the fonts to use on the desktop (can also use a percentage of the screen height (<number>%) )
 
-#DESKTOP SETTINGS (used for the left-most screen in multi-screen setups)
-desktop_visiblepanels=1 #[0/1/2] The number of panels visible by default
+#DESKTOP SETTINGS (used for the primary screen in multi-screen setups)
+desktop_visiblepanels=1 #[0 - 12] The number of panels visible by default
 desktop_backgroundfiles=/usr/share/images/desktop-base/lines-grub-1920x1080.png #list of absolute file paths for image files (disable for Lumina default)
 desktop_backgroundrotateminutes=5 #[positive integer] number of minutes between background rotations (if multiple files)
 desktop_plugins=desktopview, calendar #list of plugins to be shown on the desktop by default
+desktop_generate_icons=true #[true/false] Auto-generate launchers for ~/Desktop items
 
 #PANEL SETTINGS (preface with panel1_<setting> or panel2.<setting>, depending on the number of panels you have visible by default)
 #NOTE: If two panels, they need to be on opposite screen edges (top/bottom or left/right)
 panel1_location=top #[top/bottom/left/right] Screen edge the panel should be on
 panel1_pixelsize=4%H #number of pixels wide/high the panel should be (or <number>%[W/H] for a percentage of the screen width/height)
 panel1_autohide=false #[true/false] Have the panel become visible on mouse-over
-panel1_plugins=userbutton, taskmanager, spacer, systemtray, clock, systemdashboard #list of plugins for the panel
+panel1_plugins=systemstart, taskmanager-nogroups, spacer, systemtray, clock, battery #list of plugins for the panel
 panel1_pinlocation=center #[left/center/right] Note:[left/right] corresponds to [top/bottom] for vertical panels
 panel1_edgepercent=90 #[1->100] percentage of the screen edge to use
 
@@ -56,3 +88,20 @@ menu_plugins=terminal, filemanager, applications, line, settings #list of menu p
 #favorites_add=<file/dir path> #Create a favorites entry for this file/dir
 #favorites_remove=<file/dir path> #Remove a favorites entry for this file/dir
 #favorites_add_ifexists=<file/dir path> #Create a favorites entry for this file/dir if the file/dir exists
+favorites_add_ifexists=firefox.desktop
+favorites_add_ifexists=iceweasel.desktop
+favorites_add_ifexists=chromium-browser.desktop
+favorites_add_ifexists=qupzilla.desktop
+favorites_add_ifexists=thunderbird.desktop
+favorites_add_ifexists=icedove.desktop
+favorites_add_ifexists=trojita.desktop
+favorites_add_ifexists=mpv.desktop
+favorites_add_ifexists=vlc.desktop
+
+#QUICKLAUNCH CUSTOMIZATION (requires the use of the "systemstart" panel plugin)
+#quicklaunch_add=<file/dir path> #Create a quicklaunch shortcut for this file/dir
+#quicklaunch_add_ifexists=<file/dir path> #Create a quicklaunch shortcut for this file/dir if the file/dir exists
+
+#Generic scripts/utilities to run for any additional setup procedures
+#  These are always run after all other settings are saved
+#Format: usersetup_run=<generic command to run>

--- a/port-files/debian/rules
+++ b/port-files/debian/rules
@@ -17,7 +17,8 @@ override_dh_auto_configure:
 		L_ETCDIR=/etc \
 		QMAKE_CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" \
 		QMAKE_LFLAGS="$(LDFLAGS) -Wl,--as-needed" \
-		CONFIG+=nostrip
+		CONFIG+=nostrip \
+		CONFIG+=WITH_I18N
 
 override_dh_auto_clean:
 	dh_auto_clean
@@ -25,7 +26,7 @@ override_dh_auto_clean:
 
 override_dh_install:
 	dh_install --list-missing
-	mv $(CURDIR)/port-files/debian/lumina-desktop/usr/bin/lumina-desktop \
-		$(CURDIR)/port-files/debian/lumina-desktop/usr/bin/lumina-desktop.real
-	install -m755 $(CURDIR)/port-files/debian/lumina-desktop \
-		$(CURDIR)/port-files/debian/lumina-desktop/usr/bin/lumina-desktop
+	mv $(CURDIR)/debian/lumina-desktop/usr/bin/lumina-desktop \
+		$(CURDIR)/debian/lumina-desktop/usr/bin/lumina-desktop.real
+	install -m755 $(CURDIR)/debian/lumina-desktop.wrapper \
+		$(CURDIR)/debian/lumina-desktop/usr/bin/lumina-desktop


### PR DESCRIPTION
Changes:

* New git snapshot
* update supplied wrapper for using qt5ct with lumina
* update supplied vendor configuration for lumina
  - same as previous
  - add iceweasel, icedove, mpv, xarchiver, konsole to list of known
    applications to look for (firefox and thunderbird already were)
* move usbmount from Depends to Recommends
* move pavucontrol from Depends to Recommends
  - Note: pavucontrol is still needed for the graphical mixer utility,
          not having pavucontrol installed will disable the mixer
* add xarchiver to Recommends
* update for changes since 0.9.1
  - new, removed, moved files
  - new qmake flag for enabling translations

new builds for amd64 / i386 uploaded, armhf takes a while.