### PR TITLE
Avoid reporting exit codes when user does not care to see them

### DIFF
--- a/src-qt5/core/lumina-open/main.cpp
+++ b/src-qt5/core/lumina-open/main.cpp
@@ -327,6 +327,14 @@ void getCMD(int argc, char ** argv, QString& binary, QString& args, QString& pat
       cmd.append(" \""+inFile+"\"");
     }
   }
+
+  // Avoid sticking around and watching file if user overrides behaviour
+  QString watchFile;
+  watchFile = getenv("HOME");
+  watchFile = watchFile + "/.config/lumina-desktop/nowatch";
+  if (QFile::exists(watchFile))
+     watch = false;
+
   //qDebug() << "Found Command:" << cmd << "Extension:" << extension;
   //Clean up any leftover "Exec" field codes (should have already been replaced earlier)
   if(cmd.contains("%")){cmd = cmd.remove("%U").remove("%u").remove("%F").remove("%f").remove("%i").remove("%c").remove("%k").simplified(); }
@@ -349,7 +357,7 @@ int main(int argc, char **argv){
   if(cmd.isEmpty()){ return 0; } //no command to run (handled internally)
   qDebug() << "[lumina-open] Running Cmd:" << cmd;
   int retcode = 0;
-  
+
   if(!watch && path.isEmpty()){
       //Nothing special about this one - just start it detached (less overhead)
       QProcess::startDetached(cmd);


### PR DESCRIPTION
The lumina-open program will usually launch an application and then stick around and catch error codes, displaying an error message whenever the target program returns a non-zero exit value. Some programs misbehave and always return non-zero, causing an error to be reported whenever it closes.

In order to avoid having extra lumina-open processes running and error reports from these
misbehaving applications, I have added an option to turn off process monitoring. With this patch, lumina-open will check for the existence of a file. If the ~/.config/lumina-desktop/nowatch file exists, then lumina-open will launch the given process and immediately exit. If the nowatch file
is not present, lumina-open follows its default behaviour.

This basically gives the user (even a non-admin who cannot change .desktop files) the ability to shut off lumina-open's error reporting when working with programs that givee bad return values.