### PR TITLE
Debian packaging for 1.2.0

### DIFF
--- a/port-files/debian/changelog
+++ b/port-files/debian/changelog
@@ -1,3 +1,26 @@
+lumina-desktop (1.2.0+git2198-1nano) unstable; urgency=low
+
+  * New upstream release
+  * remove libluminautils1 package (now internal library)
+  * remove libluminautils1-dev package (now internal library)
+  * add lumina-archiver package
+  * add lumina-calculator package
+  * fix compilation with GCC 6
+  * add build-dependancy on libxcb-xinput0-dev
+    - this package is not part of Debian GNU/Linux
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Fri, 06 Jan 2017 19:32:39 +0100
+
+lumina-desktop (1.0.1~git1815-1nano) unstable; urgency=low
+
+  * New git snapshot
+  * install globs2 into lumina-data package
+  * update lumina-textedit.install
+  * update lumina-fileinfo.install
+  * update lumina-screenshot.install
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Tue, 27 Sep 2016 18:31:22 +0200
+
 lumina-desktop (1.0.1~git1638-1nano) unstable; urgency=low
 
   * New git snapshot

--- a/port-files/debian/control
+++ b/port-files/debian/control
@@ -8,44 +8,28 @@ Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
                libx11-dev, libxrender-dev, libxcomposite-dev, libxdamage-dev,
                libxcb-icccm4-dev, libxcb-damage0-dev, libxcb-util0-dev,
                libqt5x11extras5-dev, qttools5-dev-tools, libxcb-image0-dev,
-               libxcb-composite0-dev, qtdeclarative5-dev, libqt5svg5-dev
+               libxcb-composite0-dev, qtdeclarative5-dev, libqt5svg5-dev,
+               libxcb-xinput0-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/pcbsd/lumina
 
 Package: lumina-desktop
 Architecture: any
 Replaces: lumina-core (<< 0.8.3.372)
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version}),
+Depends: ${misc:Depends}, ${shlibs:Depends},
          libluminautils1, lumina-config, lumina-fm, oxygen-icon-theme,
          lumina-open, lumina-screenshot, lumina-search, lumina-info,
          lumina-xconfig, lumina-fileinfo, lxpolkit, lumina-data,
-         lumina-textedit, fluxbox, numlockx, xbacklight, xscreensaver,
-         alsa-utils, acpi, gstreamer1.0-plugins-base, procps, sysstat,
-         phonon4qt5-backend-gstreamer
+         lumina-textedit, lumina-archiver, lumina-calculator,
+         fluxbox, numlockx, xbacklight, xscreensaver, alsa-utils, acpi,
+         gstreamer1.0-plugins-base, procps, sysstat, phonon4qt5-backend-gstreamer
 Recommends: qt5-configuration-tool, usbmount, xarchiver, pavucontrol, compton
 Description: Lightweight Qt5-based desktop environment
  Metapackage depending on all other lumina packages.
 
-Package: libluminautils1
-Architecture: any
-Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, ${shlibs:Depends}
-Description: Library for the lumina desktop environment
- Utility library for the lumina desktop environment
- .
- This is the debianized version of libluminautils1.
-
-Package: libluminautils-dev
-Architecture: any
-Section: libdevel
-Depends: ${misc:Depends}, libluminautils1 (= ${binary:Version})
-Description: Development files for lumina desktop environment
- Files needed to develop plugins or extensions for the lumina desktop
- environment, or using libluminautils1 in projects.
-
 Package: lumina-config
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Configuration utility for the lumina desktop environment
  lumina-config allows to change various aspects of lumina and fluxbox, like
@@ -54,7 +38,7 @@ Description: Configuration utility for the lumina desktop environment
 
 Package: lumina-fm
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Filemanager for the lumina desktop environment
  Simple filemanager for lumina with support for multiple view modes, tabbed browsing,
@@ -62,7 +46,7 @@ Description: Filemanager for the lumina desktop environment
 
 Package: lumina-open
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: xdg-open like utility for the lumina desktop environment
  lumina-open handles opening of files and urls according to the system wide
@@ -71,7 +55,7 @@ Description: xdg-open like utility for the lumina desktop environment
 
 Package: lumina-screenshot
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Screenshot utility for the lumina desktop environment
  Simple screenshot utility that allows to snapshot the whole desktop or a
@@ -82,7 +66,7 @@ Description: Screenshot utility for the lumina desktop environment
 
 Package: lumina-search
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Search utility for the lumina desktop environment
  Simple search utility that allows to search for applications or files and
@@ -90,7 +74,7 @@ Description: Search utility for the lumina desktop environment
 
 Package: lumina-info
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Basic information utility for Lumina
  lumina-info display various information about the Lumina installation,
@@ -98,26 +82,38 @@ Description: Basic information utility for Lumina
 
 Package: lumina-xconfig
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Display configuration tool for the lumina desktop environment
  Simple multi-head aware display configuration tool for Lumina
 
 Package: lumina-fileinfo
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Desktop file editor for the lumina desktop environment
  Advanced desktop file (menu) editor for Lumina
 
 Package: lumina-textedit
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libluminautils1 (= ${binary:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Texteditor for the lumina desktop environment
  Simple Texteditor for for Lumina, featuring
  - tabs for multiple files
  - syntax highlighting
  - line wrapping
+
+Package: lumina-archiver
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: Archiver for the lumina desktop environment
+ Simple Archiver for for Lumina
+
+Package: lumina-calculator
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: Calculator for the lumina desktop environment
+ Simple Calculator for for Lumina
 
 Package: lumina-data
 Architecture: all

--- a/port-files/debian/lumina-archiver.install
+++ b/port-files/debian/lumina-archiver.install
@@ -1,0 +1,3 @@
+usr/bin/lumina-archiver
+usr/share/applications/lumina-archiver.desktop
+usr/share/lumina-desktop/i18n/l-archiver*.qm

--- a/port-files/debian/lumina-calculator.install
+++ b/port-files/debian/lumina-calculator.install
@@ -1,0 +1,3 @@
+usr/bin/lumina-calculator
+usr/share/applications/lumina-calculator.desktop
+usr/share/lumina-desktop/i18n/l-calc*.qm

--- a/port-files/debian/lumina-data.install
+++ b/port-files/debian/lumina-data.install
@@ -12,4 +12,6 @@ usr/share/lumina-desktop/menu-scripts/ls.json.sh
 usr/share/lumina-desktop/luminaDesktop.conf
 usr/share/lumina-desktop/i18n/lumina-desktop*.qm
 usr/share/wallpapers/Lumina-DE/
-usr/share/xsessions/Lumina-DE.desktop 
+usr/share/xsessions/Lumina-DE.desktop
+usr/share/lumina-desktop/globs2
+usr/share/lumina-desktop/low-battery.ogg

--- a/port-files/debian/lumina-fileinfo.install
+++ b/port-files/debian/lumina-fileinfo.install
@@ -1,3 +1,3 @@
 usr/bin/lumina-fileinfo
 usr/share/applications/lumina-fileinfo.desktop
-usr/share/lumina-desktop/i18n/lumina-fileinfo*.qm
+usr/share/lumina-desktop/i18n/l-fileinfo*.qm

--- a/port-files/debian/lumina-screenshot.install
+++ b/port-files/debian/lumina-screenshot.install
@@ -1,3 +1,3 @@
 usr/bin/lumina-screenshot
 usr/share/applications/lumina-screenshot.desktop
-usr/share/lumina-desktop/i18n/lumina-screenshot*.qm
+usr/share/lumina-desktop/i18n/l-screenshot*.qm

--- a/port-files/debian/lumina-textedit.install
+++ b/port-files/debian/lumina-textedit.install
@@ -1,4 +1,4 @@
 usr/bin/lumina-textedit
 usr/bin/lte
 usr/share/applications/lumina-textedit.desktop
-usr/share/lumina-desktop/i18n/lumina-textedit*.qm
+usr/share/lumina-desktop/i18n/l-te*.qm

--- a/port-files/debian/rules
+++ b/port-files/debian/rules
@@ -18,7 +18,8 @@ override_dh_auto_configure:
 		QMAKE_CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" \
 		QMAKE_LFLAGS="$(LDFLAGS) -Wl,--as-needed" \
 		CONFIG+=nostrip \
-		CONFIG+=WITH_I18N
+		CONFIG+=WITH_I18N \
+		QMAKE_CFLAGS_ISYSTEM= \
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
Update again after longer time.

libxcb-xinput is not part of Debian GNU/Linux repositories (though I added a build on my repo). amd64 is is live, i386 and armhf follow.