### PR TITLE
Debian updates

### DIFF
--- a/port-files/debian/changelog
+++ b/port-files/debian/changelog
@@ -1,3 +1,12 @@
+lumina-desktop (1.2.0+git2198-2nano) unstable; urgency=low
+
+  * remove qt5-configuration-tool wrappers, as it's now officially
+    supported (and user-chooseable from `lumina-config')
+  * update default Debian desktop-background path from luminaDesktop.conf
+  * run xdg-user-dirs-update from luminaDesktop.conf
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Fri, 06 Jan 2017 22:25:15 +0100
+
 lumina-desktop (1.2.0+git2198-1nano) unstable; urgency=low
 
   * New upstream release

--- a/port-files/debian/changelog
+++ b/port-files/debian/changelog
@@ -4,6 +4,7 @@ lumina-desktop (1.2.0+git2198-2nano) unstable; urgency=low
     supported (and user-chooseable from `lumina-config')
   * update default Debian desktop-background path from luminaDesktop.conf
   * run xdg-user-dirs-update from luminaDesktop.conf
+  * a few comments in rules, regarding libxcb-xinput0 package
 
  -- Christopher Roy Bratusek <nano@jpberlin.de>  Fri, 06 Jan 2017 22:25:15 +0100
 

--- a/port-files/debian/changelog
+++ b/port-files/debian/changelog
@@ -1,3 +1,9 @@
+lumina-desktop (1.2.0+git2198-3nano) unstable; urgency=low
+
+  * remove remaining artifacts for libluminautils1
+
+ -- Christopher Roy Bratusek <nano@jpberlin.de>  Sun, 08 Jan 2017 17:13:28 +0100
+
 lumina-desktop (1.2.0+git2198-2nano) unstable; urgency=low
 
   * remove qt5-configuration-tool wrappers, as it's now officially

--- a/port-files/debian/control
+++ b/port-files/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 9), qt5-qmake, qtbase5-dev, qtmultimedia5-dev,
                libxcb-composite0-dev, qtdeclarative5-dev, libqt5svg5-dev,
                libxcb-xinput0-dev
 Standards-Version: 3.9.6
-Homepage: https://github.com/pcbsd/lumina
+Homepage: https://github.com/trueos/lumina
 
 Package: lumina-desktop
 Architecture: any

--- a/port-files/debian/control
+++ b/port-files/debian/control
@@ -17,7 +17,7 @@ Package: lumina-desktop
 Architecture: any
 Replaces: lumina-core (<< 0.8.3.372)
 Depends: ${misc:Depends}, ${shlibs:Depends},
-         libluminautils1, lumina-config, lumina-fm, oxygen-icon-theme,
+         lumina-config, lumina-fm, oxygen-icon-theme,
          lumina-open, lumina-screenshot, lumina-search, lumina-info,
          lumina-xconfig, lumina-fileinfo, lxpolkit, lumina-data,
          lumina-textedit, lumina-archiver, lumina-calculator,
@@ -117,7 +117,7 @@ Description: Calculator for the lumina desktop environment
 
 Package: lumina-data
 Architecture: all
-Depends: ${misc:Depends}, libluminautils1
+Depends: ${misc:Depends}
 Replaces: lumina-core (<< 0.8.3.372)
 Description: Data files for the lumina Desktop environment
  This package provides

--- a/port-files/debian/libluminautils-dev.install
+++ b/port-files/debian/libluminautils-dev.install
@@ -1,2 +1,0 @@
-usr/lib/*/libLuminaUtils.so
-usr/include/*.h

--- a/port-files/debian/libluminautils1.install
+++ b/port-files/debian/libluminautils1.install
@@ -1,3 +1,0 @@
-usr/lib/*/libLuminaUtils.so.1
-usr/lib/*/libLuminaUtils.so.1.0
-usr/lib/*/libLuminaUtils.so.1.0.0

--- a/port-files/debian/lumina-desktop.install
+++ b/port-files/debian/lumina-desktop.install
@@ -1,4 +1,3 @@
 usr/bin/lumina-desktop
 usr/bin/start-lumina-desktop
 debian/luminaDesktop.conf   /etc
-debian/lumina-qt5ct         /etc/default

--- a/port-files/debian/lumina-desktop.wrapper
+++ b/port-files/debian/lumina-desktop.wrapper
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-. /etc/default/lumina-qt5ct
-
-if test -f /usr/bin/qt5ct && test ${LUMINA_USE_QT5CT} = TRUE; then
-	export QT_QPA_PLATFORMTHEME=qt5ct
-fi
-
-/usr/bin/lumina-desktop.real

--- a/port-files/debian/lumina-qt5ct
+++ b/port-files/debian/lumina-qt5ct
@@ -1,7 +1,0 @@
-#
-# if LUMINA_USE_QT5CT is TRUE Lumina Desktop
-# will use qt5-configuration-tool for theming
-# Qt. Please note that this will override some
-# of the Lumina settings in 'lumina-config'
-
-LUMINA_USE_QT5CT=FALSE

--- a/port-files/debian/luminaDesktop.conf
+++ b/port-files/debian/luminaDesktop.conf
@@ -67,7 +67,7 @@ theme_fontsize=10pt #Default size of the fonts to use on the desktop (can also u
 
 #DESKTOP SETTINGS (used for the primary screen in multi-screen setups)
 desktop_visiblepanels=1 #[0 - 12] The number of panels visible by default
-desktop_backgroundfiles=/usr/share/images/desktop-base/lines-grub-1920x1080.png #list of absolute file paths for image files (disable for Lumina default)
+desktop_backgroundfiles=/usr/share/images/desktop-background #list of absolute file paths for image files (disable for Lumina default)
 desktop_backgroundrotateminutes=5 #[positive integer] number of minutes between background rotations (if multiple files)
 desktop_plugins=desktopview, calendar #list of plugins to be shown on the desktop by default
 desktop_generate_icons=true #[true/false] Auto-generate launchers for ~/Desktop items
@@ -105,3 +105,4 @@ favorites_add_ifexists=vlc.desktop
 #Generic scripts/utilities to run for any additional setup procedures
 #  These are always run after all other settings are saved
 #Format: usersetup_run=<generic command to run>
+usersetup_run=xdg-user-dirs-update

--- a/port-files/debian/rules
+++ b/port-files/debian/rules
@@ -6,8 +6,24 @@ include /usr/share/dpkg/default.mk
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
+#
+# you may want to comment-out --parallel if build breaks for
+# no visible reason or without meaningful error message
+#
+
 %:
 	dh $@ --parallel
+
+# For Debian GNU/Linux which does not offer manually compiled
+# libxcb-xinput0/libxcb-xinput0-dev, add the following flag:
+#
+# CONFIG+=NO_XINPUT
+#
+# also remove
+#
+# libxcb-xinput0-dev
+#
+# from dependencies in debian/rules (obviously)
 
 override_dh_auto_configure:
 	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/qmake \
@@ -19,7 +35,7 @@ override_dh_auto_configure:
 		QMAKE_LFLAGS="$(LDFLAGS) -Wl,--as-needed" \
 		CONFIG+=nostrip \
 		CONFIG+=WITH_I18N \
-		QMAKE_CFLAGS_ISYSTEM= \
+		QMAKE_CFLAGS_ISYSTEM=
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/port-files/debian/rules
+++ b/port-files/debian/rules
@@ -27,7 +27,3 @@ override_dh_auto_clean:
 
 override_dh_install:
 	dh_install --list-missing
-	mv $(CURDIR)/debian/lumina-desktop/usr/bin/lumina-desktop \
-		$(CURDIR)/debian/lumina-desktop/usr/bin/lumina-desktop.real
-	install -m755 $(CURDIR)/debian/lumina-desktop.wrapper \
-		$(CURDIR)/debian/lumina-desktop/usr/bin/lumina-desktop


### PR DESCRIPTION
* remove qt5-configuration-tool wrappers, as it's now officiall supported (and user-chooseable from `lumina-config')
* update default Debian desktop-background path from luminaDesktop.conf
* run xdg-user-dirs-update from luminaDesktop.conf
* a few comments in rules, regarding libxcb-xinput0 package