### PR TITLE
Bugfix taskmanager

### DIFF
--- a/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskButton.cpp
+++ b/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskButton.cpp
@@ -133,7 +133,7 @@ void LTaskButton::UpdateButton(){
     //multiple windows
     this->setPopupMode(QToolButton::InstantPopup);
     this->setMenu(winMenu);
-    if(noicon || showText){ "("+QString::number(WINLIST.length())+") "+cname; }
+    if(noicon || showText){ this->setText("("+QString::number(WINLIST.length())+") "+cname); }
     else{ this->setText("("+QString::number(WINLIST.length())+")"); }
   }
   this->setState(showstate); //Make sure this is after the button setup so that it properly sets the margins/etc

--- a/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskButton.cpp
+++ b/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskButton.cpp
@@ -16,7 +16,6 @@ LTaskButton::LTaskButton(QWidget *parent, bool smallDisplay) : LTBWidget(parent)
   winMenu = new QMenu(this);
   UpdateMenus();
   showText = !smallDisplay;
-  this->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
   this->setAutoRaise(false); //make sure these always look like buttons
   this->setContextMenuPolicy(Qt::CustomContextMenu);
   this->setFocusPolicy(Qt::NoFocus);
@@ -126,15 +125,14 @@ void LTaskButton::UpdateButton(){
       QString txt = WINLIST[0].text();
       if(txt.length()>30){ txt.truncate(27); txt.append("..."); }
       else if(txt.length()<30){ txt = txt.leftJustified(30, ' '); }
-      this->setToolButtonStyle(Qt::ToolButtonTextBesideIcon); this->setText(txt);
-     }else if(noicon){ this->setToolButtonStyle(Qt::ToolButtonTextBesideIcon); this->setText( cname ); }
-    else{ this->setToolButtonStyle(Qt::ToolButtonIconOnly); this->setText(""); }
+      this->setText(txt);
+     }else if(noicon){ this->setText( cname ); }
+    else{ this->setText(""); }
     this->setToolTip(WINLIST[0].text());
   }else if(WINLIST.length() > 1){
     //multiple windows
     this->setPopupMode(QToolButton::InstantPopup);
     this->setMenu(winMenu);
-    this->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     if(noicon || showText){ "("+QString::number(WINLIST.length())+") "+cname; }
     else{ this->setText("("+QString::number(WINLIST.length())+")"); }
   }

--- a/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskManagerPlugin.cpp
+++ b/src-qt5/core/lumina-desktop/panel-plugins/taskmanager/LTaskManagerPlugin.cpp
@@ -116,8 +116,10 @@ void LTaskManagerPlugin::UpdateButtons(){
         but->addWindow( winlist[i] );
 	if(this->layout()->direction()==QBoxLayout::LeftToRight){
 	    but->setIconSize(QSize(this->height(), this->height()));
+	    but->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 	}else{
 	    but->setIconSize(QSize(this->width(), this->width()));
+	    but->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
 	}
       this->layout()->addWidget(but);
       connect(but, SIGNAL(MenuClosed()), this, SIGNAL(MenuClosed()));


### PR DESCRIPTION
* Fix button text style when using vertical panel. When the taskmanager is used in a vertical panel which has auto-hide set the button style will toggle between under/beside.
* Add missing call to setText().