### PR TITLE
Better messageboxes for closing the screenshot app.

### DIFF
--- a/src-qt5/desktop-utils/lumina-screenshot/MainUI.h
+++ b/src-qt5/desktop-utils/lumina-screenshot/MainUI.h
@@ -41,7 +41,7 @@ public slots:
 
 private:
 	Ui::MainUI *ui;
-	bool mousegrabbed, picSaved;
+	bool mousegrabbed, picSaved, closeOnSave;
 	QRect lastgeom;
 	QString ppath; //previous file path
 	WId cwin; //current window to screenshot


### PR DESCRIPTION
Instead of a Yes/No question that requires you to read the text of the
message box and decide what to do, let's give the buttons good names so
we know what the command will do.

Inspired by hitting "no" multiple times when I accidentally hit the
shortcut key to take a screenshot. (assuming it was asking "do you want
to save").

Slowly going through and fixing message boxes that could be better.