### PR TITLE
Summary: Fix the workspace switcher panel plugin when using a keyboard shortcut to change the workspace.

### DIFF
--- a/src-qt5/core/lumina-desktop-unified/src-DE/panel-plugins/desktopswitcher/LDesktopSwitcher.cpp
+++ b/src-qt5/core/lumina-desktop-unified/src-DE/panel-plugins/desktopswitcher/LDesktopSwitcher.cpp
@@ -15,7 +15,7 @@ LDesktopSwitcher::LDesktopSwitcher(QWidget *parent, QString id, bool horizontal)
   label->setPopupMode(QToolButton::DelayedPopup);
   label->setAutoRaise(true);
   label->setToolButtonStyle(Qt::ToolButtonIconOnly);
-  label->setIcon( LXDG::findIcon("preferences-desktop-display-color", "") );
+  label->setIcon( LXDG::findIcon("format-view-carousel", "preferences-desktop-display") );
   label->setToolTip(QString("Workspace 1"));
   connect(label, SIGNAL(clicked()), this, SLOT(openMenu()));
   menu = new QMenu(this);
@@ -29,6 +29,9 @@ LDesktopSwitcher::LDesktopSwitcher(QWidget *parent, QString id, bool horizontal)
 
   QTimer::singleShot(500, this, SLOT(createMenu()) ); //needs a delay to make sure it works right the first time
   QTimer::singleShot(0,this, SLOT(OrientationChange()) ); //adjust icon size
+
+  //Process the signal which is sent when the workspace is changed via keyboard-shortcuts
+  connect(QApplication::instance(), SIGNAL(WorkspaceChanged()), this, SLOT(updateWorkspaceMenu()));
 }
 
 LDesktopSwitcher::~LDesktopSwitcher(){
@@ -133,10 +136,13 @@ void LDesktopSwitcher::createMenu() {
     if(i == cur){ name.prepend("*"); name.append("*");} //identify which desktop this is currently
     menu->addAction(newAction(i, name));
   }
+  label->setToolTip(QString(tr("Workspace %1")).arg(QString::number(cur + 1)));
 }
 
 void LDesktopSwitcher::menuActionTriggered(QAction* act) {
   LSession::handle()->XCB->SetCurrentWorkspace(act->whatsThis().toInt());
-  label->setToolTip(QString(tr("Workspace %1")).arg(act->whatsThis().toInt() +1));
-  QTimer::singleShot(500, this, SLOT(createMenu()) ); //make sure the menu gets updated
+}
+
+void LDesktopSwitcher::updateWorkspaceMenu() {
+  createMenu();
 }

--- a/src-qt5/core/lumina-desktop-unified/src-DE/panel-plugins/desktopswitcher/LDesktopSwitcher.h
+++ b/src-qt5/core/lumina-desktop-unified/src-DE/panel-plugins/desktopswitcher/LDesktopSwitcher.h
@@ -49,6 +49,7 @@ private slots:
 	void openMenu();
 	void createMenu();
 	void menuActionTriggered(QAction*);
+	void updateWorkspaceMenu();
 
 public slots:
 	void LocaleChange(){

--- a/src-qt5/core/lumina-desktop/panel-plugins/desktopswitcher/LDesktopSwitcher.cpp
+++ b/src-qt5/core/lumina-desktop/panel-plugins/desktopswitcher/LDesktopSwitcher.cpp
@@ -29,6 +29,9 @@ LDesktopSwitcher::LDesktopSwitcher(QWidget *parent, QString id, bool horizontal)
 
   QTimer::singleShot(500, this, SLOT(createMenu()) ); //needs a delay to make sure it works right the first time
   QTimer::singleShot(0,this, SLOT(OrientationChange()) ); //adjust icon size
+
+  //Process the signal which is sent when the workspace is changed via keyboard-shortcuts
+  connect(QApplication::instance(), SIGNAL(WorkspaceChanged()), this, SLOT(updateWorkspaceMenu()));
 }
 
 LDesktopSwitcher::~LDesktopSwitcher(){
@@ -133,10 +136,13 @@ void LDesktopSwitcher::createMenu() {
     if(i == cur){ name.prepend("*"); name.append("*");} //identify which desktop this is currently
     menu->addAction(newAction(i, name));
   }
+  label->setToolTip(QString(tr("Workspace %1")).arg(QString::number(cur + 1)));
 }
 
 void LDesktopSwitcher::menuActionTriggered(QAction* act) {
   LSession::handle()->XCB->SetCurrentWorkspace(act->whatsThis().toInt());
-  label->setToolTip(QString(tr("Workspace %1")).arg(act->whatsThis().toInt() +1));
-  QTimer::singleShot(500, this, SLOT(createMenu()) ); //make sure the menu gets updated
+}
+
+void LDesktopSwitcher::updateWorkspaceMenu() {
+  createMenu();
 }

--- a/src-qt5/core/lumina-desktop/panel-plugins/desktopswitcher/LDesktopSwitcher.h
+++ b/src-qt5/core/lumina-desktop/panel-plugins/desktopswitcher/LDesktopSwitcher.h
@@ -49,6 +49,7 @@ private slots:
 	void openMenu();
 	void createMenu();
 	void menuActionTriggered(QAction*);
+	void updateWorkspaceMenu();
 
 public slots:
 	void LocaleChange(){


### PR DESCRIPTION
Summary:
     The workspace information wasn't getting updated in the workspace-switcher-panel-plugin(wsp)
     when the workspace was changed via keyboard-shortcut, for example ctrl-F2 etc.
     Specifically, the tooltip for the wsp would show the incorrect number for the current workspace.

Details:
     The wsp menu always did indicate the correct workspace number because the user has to click
     on the wsp to display the menu. The click-action sends a signal which updates the workspace in      the menu. But, the tooltip doesn't necessarily display the correct workspace number unless the user clicks on a workspace in the menu.

To reproduce the problem:
     1. The current workspace is workspace 1.
     2. Change to a different workspace via keyboard-shortcut, for example <ctrl-F2>.
     3. Mouse-hover over the wsp and the tooltip displays the previous workspace number which is incorrect.

Code Changes:
     The code changes are small and limited to the two source files in the desktopswitcher subdir.