### PR TITLE
lumina-desktop.pro: fix out of tree installation

### DIFF
--- a/src-qt5/core/lumina-desktop/lumina-desktop.pro
+++ b/src-qt5/core/lumina-desktop/lumina-desktop.pro
@@ -92,17 +92,17 @@ conf.path = $${L_ETCDIR}
   message("Installing defaults settings for OS: $${DEFAULT_SETTINGS}")
   OS=$${DEFAULT_SETTINGS}
 }
-exists("defaults/luminaDesktop-$${OS}.conf"){
+exists("$$PWD/defaults/luminaDesktop-$${OS}.conf"){
   message(" -- Found OS-specific system config file: $${OS}");
-  conf.extra = cp defaults/luminaDesktop-$${OS}.conf $(INSTALL_ROOT)$${L_ETCDIR}/luminaDesktop.conf.dist
+  conf.extra = cp $$PWD/defaults/luminaDesktop-$${OS}.conf $(INSTALL_ROOT)$${L_ETCDIR}/luminaDesktop.conf.dist
 }else{
-  conf.extra = cp defaults/luminaDesktop.conf $(INSTALL_ROOT)$${L_ETCDIR}/luminaDesktop.conf.dist
+  conf.extra = cp $$PWD/defaults/luminaDesktop.conf $(INSTALL_ROOT)$${L_ETCDIR}/luminaDesktop.conf.dist
 }
-exists("defaults/desktop-background-$${OS}.jpg"){
+exists("$$PWD/defaults/desktop-background-$${OS}.jpg"){
   message(" -- Found OS-specific background image: $${OS}");
-  defaults.extra = cp defaults/desktop-background-$${OS}.jpg $(INSTALL_ROOT)$${L_SHAREDIR}/lumina-desktop/desktop-background.jpg
+  defaults.extra = cp $$PWD/defaults/desktop-background-$${OS}.jpg $(INSTALL_ROOT)$${L_SHAREDIR}/lumina-desktop/desktop-background.jpg
 }else{
-  defaults.extra = cp defaults/desktop-background.jpg $(INSTALL_ROOT)$${L_SHAREDIR}/lumina-desktop/desktop-background.jpg
+  defaults.extra = cp $$PWD/defaults/desktop-background.jpg $(INSTALL_ROOT)$${L_SHAREDIR}/lumina-desktop/desktop-background.jpg
 }
 
 TRANSLATIONS =  i18n/lumina-desktop_af.ts \


### PR DESCRIPTION
Fixes:
| cp: cannot stat 'defaults/desktop-background.jpg': No such file or directory

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>