### PR TITLE
Don't close editor when user cancels save dialog.

### DIFF
--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
@@ -252,7 +252,6 @@ void MainUI::CloseFile(){
 }
 
 void MainUI::SaveFile(){
-  qDebug() << "SaveFile";
   PlainTextEditor *cur = currentEditor();
   if(cur==0){ return; }
   cur->SaveFile();

--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
@@ -505,7 +505,6 @@ PlainTextEditor *cur = currentEditor();
   }
 }
 
-
 //=============
 //   PROTECTED
 //=============

--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
@@ -529,7 +529,8 @@ void MainUI::closeEvent(QCloseEvent *ev){
           this,
           tr("Save Changes before closing?"),
           QString(tr("There are unsaved changes.\nDo you want save them before you close the editor?\n\n%1")).arg(unsaved.join("\n")),
-          QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::No);
+          QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
+          QMessageBox::No);
 
   if(but == QMessageBox::Cancel){
     ev->ignore();

--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.cpp
@@ -200,7 +200,6 @@ QStringList MainUI::unsavedFiles(){
   return unsaved;
 }
 
-
 // =================
 //    PRIVATE SLOTS
 //=================

--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.h
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.h
@@ -44,7 +44,7 @@ private:
 	//Simplification functions
 	PlainTextEditor* currentEditor();
 	QString currentFileDir();
-  QStringList unsavedFiles();
+	QStringList unsavedFiles();
 
 private slots:
 	//Main Actions
@@ -61,7 +61,7 @@ private slots:
 
 	//Other Menu Actions
 	void UpdateHighlighting(QAction *act = 0);
-    void showToolbar(bool);
+	void showToolbar(bool);
 	void showLineNumbers(bool);
 	void wrapLines(bool);
 	void ModifyColors();

--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.h
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.h
@@ -44,7 +44,7 @@ private:
 	//Simplification functions
 	PlainTextEditor* currentEditor();
 	QString currentFileDir();
-    QStringList unsavedFiles();
+  QStringList unsavedFiles();
 
 private slots:
 	//Main Actions

--- a/src-qt5/desktop-utils/lumina-textedit/MainUI.h
+++ b/src-qt5/desktop-utils/lumina-textedit/MainUI.h
@@ -44,6 +44,7 @@ private:
 	//Simplification functions
 	PlainTextEditor* currentEditor();
 	QString currentFileDir();
+    QStringList unsavedFiles();
 
 private slots:
 	//Main Actions


### PR DESCRIPTION
When the user tries to close an editor with unsaved changes, he is presented with a dialog asking whether to save the files. Clicking Yes opens the save dialog. If the save dialog is cancelled, the editor closes. This is imo unexpected and non-standard behavior. This change makes it so that only the dialog is closed on cancel.
When pop-ups are disabled, cancelling the dialog closes the editor like before.