### PR TITLE
Sort snapshots by name in lumina-fm

### DIFF
--- a/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.cpp
+++ b/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.cpp
@@ -176,6 +176,7 @@ void DirWidget::LoadSnaps(QString basedir, QStringList snaps){
   //Save these value internally for use later
   //qDebug() << "ZFS Snapshots available:" << basedir << snaps;
   snapbasedir = basedir;
+  snaps.sort();
   snapshots = snaps;
   //if(!snapbasedir.isEmpty()){ watcher->addPath(snapbasedir); } //add this to the watcher in case snapshots get created/removed
   //Now update the UI as necessary


### PR DESCRIPTION
This isn't ideal since one would like to sort on creation date instead of name, but name makes more sense then what it is now because at least the lpreserver snapshots get put in correct order.